### PR TITLE
Add chown for logging directory to prevent permission error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ LABEL maintainer="tjveil@gmail.com" \
       org.opencontainers.image.description="Single-node CockroachDB for CI/CD and testing" \
       org.opencontainers.image.licenses="Apache-2.0"
 
+# Ensure the directory exists
+RUN mkdir -p /cockroach && chown -R 1000:1000 /cockroach
+
 # Copy files with appropriate ownership for the cockroach user (UID 1000)
 COPY --chown=1000:1000 --chmod=755 init.sh /cockroach/
 COPY --chown=1000:1000 logs.yaml optimizations.sql /cockroach/


### PR DESCRIPTION
An unknown change recently has caused the Docker image to fail on startup due to the user not having permission to access the folder specified for logging.

This adds a command to create the directory if it does not exist and make sure it is owned by the correct user, fixing the issue.